### PR TITLE
Adapting for EQ Usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .pkg
 .uptodate
 cmd/prom-aggregation-gateway/prom-aggregation-gateway
+bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,58 @@
+# Accept the Go version for the image to be set as a build argument.
+# Default to Go 1.13
+ARG GO_VERSION=1.13
+
+# Dev stage
+FROM golang:${GO_VERSION} AS dev_builder
+RUN apt-get update -qq
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+WORKDIR /go/src/github.com/adharmonics/prom-aggregation-gateway
+COPY . .
+
+# First stage: build the executable.
+FROM golang:${GO_VERSION}-alpine AS builder
+
+# Create the user and group files that will be used in the running container to
+# run the process as an unprivileged user.
+RUN mkdir /user && \
+  echo 'nobody:x:65534:65534:nobody:/:' > /user/passwd && \
+  echo 'nobody:x:65534:' > /user/group
+
+# Install the Certificate-Authority certificates for the app to be able to make
+# calls to HTTPS endpoints.
+# Git is required for fetching the dependencies.
+RUN apk add --no-cache ca-certificates git
+
+# Set the working directory to $GOPATH
+WORKDIR /go/src/github.com/adharmonics/prom-aggregation-gateway
+
+# Import the code from the context.
+COPY ./ ./
+
+# Build the executable to `/app`. Mark the build as statically linked.
+RUN CGO_ENABLED=0 go build \
+  -installsuffix 'static' \
+  -o /bin/app ./cmd/prom-aggregation-gateway
+
+# Final stage: the running container.
+FROM scratch AS final
+
+# Import the user and group files from the first stage.
+COPY --from=builder /user/group /user/passwd /etc/
+
+# Import the Certificate-Authority certificates for enabling HTTPS.
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+# Import the compiled executable from the first stage.
+COPY --from=builder /bin/app /bin/app
+
+# Declare the port on which the webserver will be exposed.
+# As we're going to run the executable as an unprivileged user, we can't bind
+# to ports below 1024.
+EXPOSE 8080
+
+# Perform any further action as an unprivileged user.
+USER 65534:65534
+
+# Run the compiled binary.
+ENTRYPOINT ["/bin/app"]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ Prometheus Aggregation Gateway is a aggregating push gateway for Prometheus.  As
 * Gauges are also added up (but this may not make any sense)
 * Summaries are discarded.
 
+## EQ Development Setup
+
+1. Install Docker (https://www.docker.com/)
+1. `./script/setup.sh` will update/download packages and generate Docker container
+1. `./script/test.sh (test_folder)` will run tests
+1. `./script/run.sh` will run the app
+
 ## How to use
 
 Send metrics in [Prometheus format](https://prometheus.io/docs/instrumenting/exposition_formats/) to `/metrics/`

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 steps:
 - name: 'docker/compose:1.24.0'
   id: 'Run tests'
-  args: ['-f', './docker-compose.yml', 'run', 'web', 'go', 'test', '-cover', '-race', './...']
+  args: ['-f', './docker-compose.yml', 'run', 'web', 'go', 'test', '-cover', '-race', './cmd/prom-aggregation-gateway/...']
 - name: 'gcr.io/cloud-builders/docker'
   id: 'Build image'
   waitFor: ['-']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,11 @@
+steps:
+- name: 'docker/compose:1.24.0'
+  id: 'Run tests'
+  args: ['-f', './docker-compose.yml', 'run', 'web', 'go', 'test', '-cover', '-race', './...']
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'Build image'
+  waitFor: ['-']
+  args: ['build', '-t', 'us.gcr.io/everquote-container-registry/prom-aggregation-gateway:$SHORT_SHA', '.']
+images: ['us.gcr.io/everquote-container-registry/prom-aggregation-gateway:$SHORT_SHA']
+options:
+ machineType: 'N1_HIGHCPU_8'

--- a/cmd/prom-aggregation-gateway/main.go
+++ b/cmd/prom-aggregation-gateway/main.go
@@ -259,10 +259,12 @@ func (a *aggate) handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	listen := flag.String("listen", ":80", "Address and port to listen on.")
+	listen := flag.String("listen", ":8080", "Address and port to listen on.")
 	cors := flag.String("cors", "*", "The 'Access-Control-Allow-Origin' value to be returned.")
 	pushPath := flag.String("push-path", "/metrics/", "HTTP path to accept pushed metrics.")
 	flag.Parse()
+
+	log.Println("PAG started on port", *listen)
 
 	a := newAggate()
 	http.HandleFunc("/metrics", a.handler)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.4'
+services:
+  web:
+    build:
+      context: .
+      target: dev_builder
+    command:
+      - "/bin/sh"
+      - -ecx
+      - |
+        echo 'Compiling prom-aggregation-gateway!'
+        CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o bin/app ./cmd/prom-aggregation-gateway
+        echo 'Starting prom-aggregation-gateway'
+        ./bin/app --listen=:8080
+    ports:
+      - '1234:8080'
+    volumes:
+      - .:/go/src/github.com/adharmonics/prom-aggregation-gateway

--- a/script/nuke.sh
+++ b/script/nuke.sh
@@ -1,0 +1,12 @@
+
+#!/bin/sh
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "==> Deleting all containers, volumes, networks and images..."
+docker-compose -f ./docker-compose.yml down --rmi=local --volumes --remove-orphans
+docker system prune --volumes -f
+
+echo "==> App was nuked!"

--- a/script/run.sh
+++ b/script/run.sh
@@ -1,0 +1,12 @@
+
+#!/bin/sh
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "==> Cleaning up..."
+docker-compose -f ./docker-compose.yml down --rmi=local --volumes --remove-orphans
+
+echo "==> Running prom-aggregation-gateway..."
+docker-compose -f ./docker-compose.yml up --build

--- a/script/setup.sh
+++ b/script/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "==> Building docker container and initializing everything..."
+docker-compose -f ./docker-compose.yml down --rmi=local --volumes --remove-orphans
+docker-compose -f ./docker-compose.yml build
+
+echo "==> App is now ready to go!"

--- a/script/test.sh
+++ b/script/test.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+[ -z "$DEBUG" ] || set -x
+
+echo "==> Running prom-aggregation-gateway tests..."
+
+docker-compose -f ./docker-compose.yml run --rm web go test -cover -race ./cmd/prom-aggregation-gateway/...


### PR DESCRIPTION
The [original PAG structure](https://github.com/weaveworks/prom-aggregation-gateway) have a Dockerization fit for Weaveworks workflow. This PR is focused on adapting this repo structure to fit better EQ workflow.

This is a less aggressive change than https://github.com/adharmonics/prom-aggregation-gateway/pull/1 and is focused on make future changes on the main code on this fork easily transferable to the original repository.

- [x] Scripts
- [x] EQ-like Dockerization and cloudbuild
- [x] Small change on default port (`:80` requires special privilege)